### PR TITLE
Fix docstring typo

### DIFF
--- a/exercises/src/training/exercises/ex05_odds.clj
+++ b/exercises/src/training/exercises/ex05_odds.clj
@@ -5,7 +5,7 @@
 ;;
 ;; Examples:
 ;; (odds 3 6 6) => 1/18
-;; (odds 3 4 4) => 1/6
+;; (odds 3 4 4) => 1/8
 ;;
 ;; In both these examples, 3 is the sum. The other two numbers are the
 ;; number of sides the dice have.


### PR DESCRIPTION
Minor typo in the example docstring. The example solution also gives 1/8 as a result, so it's just a typo.